### PR TITLE
Update autocomplete sort to start with search term and switch to new footer and header

### DIFF
--- a/src/attractions.php
+++ b/src/attractions.php
@@ -1,15 +1,9 @@
-<html lang="en">
-<head>
-    <?php require "common_head.php"; ?>
-    <script defer src="/scripts/attraction.js"></script>
-</head>
-<body style="text-align: center;" class="text-center">
-    <!-- Jumbotron -->
-    <div class="jumbotron">
-        <h1>MHCT Attraction Rate</h1>
-        <a href="/" class="clickable"><span class="glyphicon glyphicon-chevron-left"></span> MHCT Tools</a>
-    </div>
-    <div class="container">
+<?php
+    $title = "MHCT Attraction Rate";
+    // $css = "styles/loot.css";
+    $js = "scripts/attraction.js";
+    require_once "new-common-header.php";
+?>
 
         <input id="prev_mouse" type="hidden" value="<?php (!empty($_GET['mouse']) ? print $_GET['mouse'] : '' ) ?>">
         <input id="prev_timefilter" type="hidden" value="<?php (!empty($_GET['timefilter']) ? print $_GET['timefilter'] : 'all' ) ?>">
@@ -32,10 +26,6 @@
 
     <div id="results" class="table-responsive"></div>
 
-    <br/><p class="text-center">For more info, copy of the data, or if you want to help with data gathering, please look <a href="/">here</a>.</p>
-
 </div>
 <div id="loader" class="loader"></div>
-<?php require "common_footer.php"; ?>
-</body>
-</html>
+<?php require_once "new-common-footer.php"; ?>

--- a/src/converter.php
+++ b/src/converter.php
@@ -1,38 +1,25 @@
-<html lang="en">
-<head>
-    <title>MHCT Converter</title>
-    <?php require "common_head.php"; ?>
-    <script defer src="/scripts/converter.js"></script>
-</head>
-<body style="text-align: center;" class="text-center">
-    <!-- Jumbotron -->
-    <div class="jumbotron">
-        <h1>MHCT Converter</h1>
-        <p>Search contents by convertible name.</p>
-        <a href="/" class="clickable"><span class="glyphicon glyphicon-chevron-left"></span> MHCT Tools</a>
-    </div>
-    <div class="container">
+<?php
+    $title = "MHCT Converter";
+    // $css = "styles/loot.css";
+    $js = "scripts/converter.js";
+    require_once "new-common-header.php";
+?>
+
         <input id="item_type" type="hidden" value="convertible">
         <?php
 
         if (!empty($_GET['item'])) {
             print '<input id="prev_item" type="hidden" value="' . $_GET['item'] . '">';
-        }
+        } ?>
 
-        print '
-            <div class="input-group col-sm-6 col-sm-offset-3">
-                <div class="input-group-addon"><strong>Convertible:</strong></div>
-                <input name="item" id="item" class="form-control input-lg" type="text" placeholder="Start typing convertible name and select." autofocus>
-                <div id="erase_item" class="input-group-addon fakebutton"><span class="glyphicon glyphicon-remove"></span></div>
-            </div>';
+        <div class="input-group col-sm-6 col-sm-offset-3">
+            <div class="input-group-addon"><strong>Convertible:</strong></div>
+            <input name="item" id="item" class="form-control input-lg" type="text" placeholder="Start typing convertible name and select." autofocus>
+            <div id="erase_item" class="input-group-addon fakebutton"><span class="glyphicon glyphicon-remove"></span></div>
+        </div>
 
-        //Ajax here
-        print '<div id="results_total"></div>';
-        print '<div id="results" class="table-responsive"></div>';
+        <div id="results_total"></div>
+        <div id="results" class="table-responsive"></div>
 
-        print '<br/><p class="text-center">For more info, copy of the data, or if you want to help with data gathering, please look <a href="/">here</a>.</p>';
-        ?>
-    </div>
-    <?php require "common_footer.php"; ?>
-</body>
-</html>
+
+<?php require "new-common-footer.php"; ?>

--- a/src/loot.php
+++ b/src/loot.php
@@ -1,17 +1,9 @@
-<html lang="en">
-<head>
-    <title>MHCT Looter</title>
-    <?php require "common_head.php"; ?>
-    <script defer src="/scripts/loot.js"></script>
-    <link rel="stylesheet" type="text/css" href="styles/loot.css">
-</head>
-<body style="text-align: center;" class="text-center">
-    <!-- Jumbotron -->
-    <div class="jumbotron">
-        <h1>MHCT Loot Search</h1>
-        <a href="https://agiletravels.com" class="clickable"><span class="glyphicon glyphicon-chevron-left"></span> MHCT Tools</a>
-    </div>
-    <div class="container">
+<?php
+    $title = "MHCT Looter";
+    $css = "styles/loot.css";
+    $js = "scripts/loot.js";
+    require_once "new-common-header.php";
+?>
         <form id="search_options">
         <input id="prev_item" type="hidden" value="<?php (!empty($_GET['item']) ? print $_GET['item'] : '' ) ?>">
         <input id="prev_timefilter" type="hidden" value="<?php (!empty($_GET['timefilter']) ? print $_GET['timefilter'] : 'all' ) ?>">
@@ -55,8 +47,4 @@
 
         <div id="results" class="table-responsive"></div>
 
-        <br/><p class="text-center">For more info, copy of the data, or if you want to help with data gathering, please look <a href="https://www.agiletravels.com">here</a>.</p>
-    </div>
-    <?php require "common_footer.php"; ?>
-</body>
-</html>
+<?php require_once "new-common-footer.php"; ?>

--- a/src/mapper.php
+++ b/src/mapper.php
@@ -1,38 +1,24 @@
-<html lang="en">
-<head>
-    <title>MHCT Mapper</title>
-    <?php require "common_head.php"; ?>
-    <script defer src="/scripts/mapper.js"></script>
-</head>
-<body style="text-align: center;" class="text-center">
-    <!-- Jumbotron -->
-    <div class="jumbotron">
-        <h1>MHCT Mapper</h1>
-        <a href="/" class="clickable"><span class="glyphicon glyphicon-chevron-left"></span> MHCT Tools</a>
-    </div>
-    <div class="container">
+<?php
+    $title = "MHCT Mapper";
+    // $css = "styles/loot.css";
+    $js = "scripts/mapper.js";
+    require_once "new-common-header.php";
+?>
+
         <input id="item_type" type="hidden" value="loot">
         <?php
-
         if (!empty($_GET['item'])) {
             print '<input id="prev_item" type="hidden" value="' . $_GET['item'] . '">';
-        }
+        } ?>
 
-        print '
-            <div class="input-group col-sm-6 col-sm-offset-3">
-                <div class="input-group-addon"><strong>Map:</strong></div>
-                <input name="item" id="item" class="form-control input-lg" type="text" placeholder="Start typing map name and select." autofocus>
-                <div id="erase_item" class="input-group-addon fakebutton"><span class="glyphicon glyphicon-remove"></span></div>
-            </div>
+        <div class="input-group col-sm-6 col-sm-offset-3">
+            <div class="input-group-addon"><strong>Map:</strong></div>
+            <input name="item" id="item" class="form-control input-lg" type="text" placeholder="Start typing map name and select." autofocus>
+            <div id="erase_item" class="input-group-addon fakebutton"><span class="glyphicon glyphicon-remove"></span></div>
+        </div>
         <br/>';
 
-        //Ajax here
-        print '<div id="results_total"></div>';
-        print '<div id="results" class="table-responsive"></div>';
-
-        print '<br/><p class="text-center">For more info, copy of the data, or if you want to help with data gathering, please look <a href="https://www.agiletravels.com">here</a>.</p>';
-        ?>
+        <div id="results_total"></div>
+        <div id="results" class="table-responsive"></div>
     </div>
-    <?php require "common_footer.php"; ?>
-</body>
-</html>
+<?php require_once "new-common-footer.php"; ?>

--- a/src/scripts/attraction.js
+++ b/src/scripts/attraction.js
@@ -65,6 +65,11 @@ $( function() {
         $('#mouse').autocomplete({
             source: function(request, response) {
                 var results = $.ui.autocomplete.filter(mice, request.term);
+
+                results.sort(function(a, b) {
+                    return a.value.toUpperCase().indexOf(request.term.toUpperCase()) - b.value.toUpperCase().indexOf(request.term.toUpperCase());
+                });
+
                 response(results.slice(0, 10));
             },
             delay: 0,

--- a/src/scripts/converter.js
+++ b/src/scripts/converter.js
@@ -50,6 +50,11 @@ $( function() {
         $('#item').autocomplete({
             source: function(request, response) {
                 var results = $.ui.autocomplete.filter(items, request.term);
+
+                results.sort(function(a, b) {
+                    return a.value.toUpperCase().indexOf(request.term.toUpperCase()) - b.value.toUpperCase().indexOf(request.term.toUpperCase());
+                });
+
                 response(results.slice(0, 10));
             },
             delay: 0,

--- a/src/scripts/loot.js
+++ b/src/scripts/loot.js
@@ -67,7 +67,7 @@ $(function() {
         $('#item').autocomplete({
             source: function(request, response) {
                 var results = $.ui.autocomplete.filter(items, request.term);
-console.log(results);
+
                 results.sort(function(a, b) {
                     return a.value.toUpperCase().indexOf(request.term.toUpperCase()) - b.value.toUpperCase().indexOf(request.term.toUpperCase());
                 });

--- a/src/scripts/loot.js
+++ b/src/scripts/loot.js
@@ -67,6 +67,11 @@ $(function() {
         $('#item').autocomplete({
             source: function(request, response) {
                 var results = $.ui.autocomplete.filter(items, request.term);
+console.log(results);
+                results.sort(function(a, b) {
+                    return a.value.toUpperCase().indexOf(request.term.toUpperCase()) - b.value.toUpperCase().indexOf(request.term.toUpperCase());
+                });
+
                 response(results.slice(0, 10));
             },
             delay: 0,

--- a/src/scripts/mapper.js
+++ b/src/scripts/mapper.js
@@ -50,6 +50,11 @@ $( function() {
         $('#item').autocomplete({
             source: function(request, response) {
                 var results = $.ui.autocomplete.filter(items, request.term);
+
+                results.sort(function(a, b) {
+                    return a.value.toUpperCase().indexOf(request.term.toUpperCase()) - b.value.toUpperCase().indexOf(request.term.toUpperCase());
+                });
+
                 response(results.slice(0, 10));
             },
             delay: 0,

--- a/src/searchByItem.php
+++ b/src/searchByItem.php
@@ -91,7 +91,7 @@ function getLootQuery(&$query_all, &$query_one) {
     $table = generateTable("drops");
 
     # blocking gold
-    $query_all = 'SELECT hg_item_id as id, name FROM loot UNION SELECT hg_item_id as id, plural_name as name FROM loot';
+    $query_all = 'SELECT hg_item_id AS id, name FROM loot UNION SELECT hg_item_id AS id, plural_name AS name FROM loot WHERE plural_name IS NOT NULL';
     $query_one = '
         SELECT l.name AS location, s.name AS stage, h.total_hunts, c.name AS cheese, h.total_catches
           , h.total_drops, ROUND(h.drop_count/h.total_catches*100,2) AS drop_pct, h.min_amt, h.max_amt
@@ -126,12 +126,12 @@ function getMapQuery(&$query_all, &$query_one) {
 
 function getConvertibleQuery(&$query_all, &$query_one) {
     $query_all = 'SELECT c.id, c.name FROM mhconverter.convertibles c ORDER BY c.name ASC';
-    $query_one = 'SELECT aci.convertible_id as conv, i.name as item, 
+    $query_one = 'SELECT aci.convertible_id as conv, i.name as item,
         aci.total_convertibles_opened as total,	aci.total_item_quantity as total_items,
-        aci.single_convertibles_opened as single_opens, aci.times_with_any, 
-        aci.min_item_quantity, aci.max_item_quantity, aci.total_quantity_when_any 
-        from aggr_convertible_item aci 
-	        inner join items i 
-		        on aci.item_id = i.id 
+        aci.single_convertibles_opened as single_opens, aci.times_with_any,
+        aci.min_item_quantity, aci.max_item_quantity, aci.total_quantity_when_any
+        from aggr_convertible_item aci
+	        inner join items i
+		        on aci.item_id = i.id
         where aci.convertible_id = ?';
 }

--- a/src/tracker.php
+++ b/src/tracker.php
@@ -1,15 +1,10 @@
-<html lang="en">
-<head>
-    <title>MHCT Tracker</title>
-    <?php require "common_head.php"; ?>
-</head>
-<body style="text-align: center;" class="text-center">
-    <!-- Jumbotron -->
-    <div class="jumbotron">
-        <h1>MHCT Tracker</h1>
-        <a href="/" class="clickable"><span class="glyphicon glyphicon-chevron-left"></span> MHCT Tools</a>
-    </div>
-    <div class="container">
+<?php
+    $title = "MHCT Tracker";
+    // $css = "styles/loot.css";
+    // $js = "scripts/attraction.js";
+    require_once "new-common-header.php";
+?>
+
         <?php
         $file_name = 'tracker.json';
         $location = 'Unknown';
@@ -37,11 +32,8 @@
             <small>Last seen (after last move): <?php print $time_since; ?> ago.</small>
         </h3><br/><br/>
 
-        <?php require_once "stats.php"; ?><br/><br/>
+        <?php require_once "stats.php"; ?><br/>
         <?php //require_once "missing_mice.php"; ?>
 
-        <br/><p class="text-center">For more info, copy of the data, or if you want to help with data gathering, please look <a href="/">here</a>.</p>
-    </div>
-    <?php require "common_footer.php"; ?>
-</body>
-</html>
+
+<?php require_once "new-common-footer.php"; ?>


### PR DESCRIPTION
* The php files just switch to new header and footer, removing duplication.
* The searchByItem.php was returning blank results for plural names of loot, fixed that
* The js files added a sort of autocomplete to show the results that start with users string first

tested on local